### PR TITLE
Add event code to scraper output

### DIFF
--- a/lib/oscn_scraper/parsers/events.rb
+++ b/lib/oscn_scraper/parsers/events.rb
@@ -1,3 +1,5 @@
+require 'byebug'
+
 module OscnScraper
   module Parsers
     # Description/Explanation of Case class
@@ -35,12 +37,14 @@ module OscnScraper
         date_string = event.css('td font[color="green"]').text # Date
         date = parsed_date(date_string)
         event_type = event.css('td')[0].children[3].text.squish # Event Type
+        event_code = event.search('.//comment()').text.squish.gsub('(', '').gsub(')', '')
         party_name = event.css('td')[1].text.strip
         docket = event.css('td')[2].text.strip
 
         events[:events] << {
           date: date,
           event_type: event_type,
+          event_code: event_code,
           party_name: party_name,
           docket: docket
         }

--- a/spec/parsers/events_spec.rb
+++ b/spec/parsers/events_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe OscnScraper::Parsers::Events do
       parsed_html = html_doc.css('table')
       data = described_class.parse(parsed_html)
 
+
       expect(data[:events].count).to eq 13
       expect(data[:events].first).to include({ date: DateTime.new(2017, 4, 6, 13, 30, 0o0, '-0600'),
                                                event_type: 'PRELIMINARY HEARING CONFERENCE',
+                                               event_code: 'PRELIMC',
                                                party_name: 'CARGLE,  EDWARD  III',
                                                docket: 'Larry Shaw' })
     end

--- a/spec/parsers/events_spec.rb
+++ b/spec/parsers/events_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe OscnScraper::Parsers::Events do
       parsed_html = html_doc.css('table')
       data = described_class.parse(parsed_html)
 
-
       expect(data[:events].count).to eq 13
       expect(data[:events].first).to include({ date: DateTime.new(2017, 4, 6, 13, 30, 0o0, '-0600'),
                                                event_type: 'PRELIMINARY HEARING CONFERENCE',


### PR DESCRIPTION
## Description

Add event code to scraper from the comment in the code. This code is a normalize version of the event.

## How to test

Adjusted parser spec