### PR TITLE
Fix link bug

### DIFF
--- a/lib/oscn_scraper/parsers/link.rb
+++ b/lib/oscn_scraper/parsers/link.rb
@@ -25,9 +25,8 @@ module OscnScraper
         uri = URI.parse(@link_html.at('a')['href'])
         params = CGI.parse(uri.query)
         {
-
           case_number: @link_html.at('a').text,
-          link: @link_html.at('a')['href'].first,
+          link: @link_html.at('a')['href'],
           oscn_id: params['casemasterID'].first.to_i,
           county: params['db'].first
         }

--- a/spec/fixtures/parsers/links/link.html
+++ b/spec/fixtures/parsers/links/link.html
@@ -1,3 +1,1 @@
 <A HREF="GetCaseInformation.asp?viewtype=&submitted=true&casemasterID=3946802&db=Oklahoma">CF-2021-489</A>
-
-		

--- a/spec/parsers/link_spec.rb
+++ b/spec/parsers/link_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe OscnScraper::Parsers::Link do
     data = described_class.parse(link_html)
 
     expect(data[:case_number]).to eq 'CF-2021-489'
+    expect(data[:link]).to eq 'GetCaseInformation.asp?viewtype=&submitted=true&casemasterID=3946802&db=Oklahoma'
     expect(data[:county]).to eq 'Oklahoma'
     expect(data[:oscn_id]).to eq 3_946_802
   end


### PR DESCRIPTION
## Description

Add spec for link parsing to fix error where `:link` data was just the first character of the string

## How to test


## Checklist
