### PR TITLE
Add docket event links to json payload

### DIFF
--- a/lib/oscn_scraper/parsers/docket_events.rb
+++ b/lib/oscn_scraper/parsers/docket_events.rb
@@ -35,10 +35,21 @@ module OscnScraper
             description: sanitize_data(row.css('td')[2]),
             count: sanitize_data(row.css('td')[3]),
             party: sanitize_data(row.css('td')[4]),
-            amount: sanitize_data(row.css('td')[5])
+            amount: sanitize_data(row.css('td')[5]),
+            links: parse_links(row)
           }
         end
         docket_events
+      end
+
+      def parse_links(row)
+        data = row.css('a').map{ |link| { title: link.text, link: "https://www.oscn.net/dockets/#{link['href']}", oscn_id: extract_id(link['href']) } }
+      end
+
+      def extract_id(link_url)
+        url = URI.parse(link_url)
+        params = CGI.parse(url.query)
+        params['bc'].first
       end
 
       def date(data)

--- a/lib/oscn_scraper/parsers/docket_events.rb
+++ b/lib/oscn_scraper/parsers/docket_events.rb
@@ -43,7 +43,7 @@ module OscnScraper
       end
 
       def parse_links(row)
-        data = row.css('a').map{ |link| { title: link.text, link: "https://www.oscn.net/dockets/#{link['href']}", oscn_id: extract_id(link['href']) } }
+        row.css('a').map { |link| { title: link.text, link: "https://www.oscn.net/dockets/#{link['href']}", oscn_id: extract_id(link['href']) } }
       end
 
       def extract_id(link_url)

--- a/spec/fixtures/parsers/docket_events/with_link.html
+++ b/spec/fixtures/parsers/docket_events/with_link.html
@@ -1,0 +1,289 @@
+<h2 class="section dockets">Docket</h2>
+<table class="docketlist ocis" cellpadding="2" cellspacing="2" border="0" id="TABLE_5">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Code</th>
+        <th>Description</th>
+        <th>Count</th>
+        <th>Party</th>
+        <th>Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="docketRow oddRow primary-entry">
+        <td valign="top">
+          <font color="black"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="black"><nobr>TEXT</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="black">SMALL CLAIMS INITIAL FILING.</font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"><span class="count_issue">1&nbsp;&nbsp;</span></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow evenRow primary-entry">
+        <td valign="top">
+          <font color="000000"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="000000"><nobr>SCFED1</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="000000">FORCIBLE ENTRY &amp; DETAINER &lt;$5000.00.</font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow oddRow primary-entry">
+        <td valign="top">
+          <font color="GREEN"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="GREEN"><nobr>AFDC1</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="GREEN">AFFIDAVIT</font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right">
+          <font color="green">$ 45.00</font>
+        </td>
+      </tr>
+      <tr class="docketRow evenRow primary-entry">
+        <td valign="top">
+          <font color="GREEN"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="GREEN"><nobr>DMFE</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="GREEN">DISPUTE MEDIATION FEE</font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right">
+          <font color="green">$ 7.00</font>
+        </td>
+      </tr>
+      <tr class="docketRow oddRow primary-entry">
+        <td valign="top">
+          <font color="GREEN"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="GREEN"><nobr>PFE7</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="GREEN">LAW LIBRARY FEE</font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right">
+          <font color="green">$ 6.00</font>
+        </td>
+      </tr>
+      <tr class="docketRow evenRow primary-entry">
+        <td valign="top">
+          <font color="BLACK"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="BLACK"><nobr>ANMS</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="BLACK">AFFIDAVIT AS TO  MILITARY SERVICE - SMALL CLAIMS</font>
+            </p>
+            <p><span style="text-decoration: italic;">Document Available at Court Clerk's Office</span></p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow oddRow primary-entry">
+        <td valign="top">
+          <font color="black"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="black"><nobr>P</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="black">PETITION /  FED /  $   1,818.60</font>
+            </p>
+            <p><span style="text-decoration: italic;">
+									Document Available (#1048798689)
+									<nobr><a class="doc-tif" href="GetDocument.aspx?ct=Oklahoma&amp;cn=SC-2021-17934&amp;bc=1048798689&amp;fmt=tif" target="_blank" title="Download document in TIFF format.">TIFF</a></nobr>
+									&nbsp;&nbsp;
+									<nobr><a class="doc-pdf" href="GetDocument.aspx?ct=Oklahoma&amp;bc=1048798689&amp;cn=SC-2021-17934&amp;fmt=pdf" target="_blank" title="Download document in PDF format.">PDF</a></nobr></span></p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow evenRow primary-entry">
+        <td valign="top">
+          <font color="black"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="black"><nobr>EAA</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="black">ENTRY OF APPEARANCE/SMALL CLAIMS</font>
+            </p>
+            <p><span style="text-decoration: italic;">Document Available at Court Clerk's Office</span></p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow oddRow primary-entry">
+        <td valign="top">
+          <font color="black"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="black"><nobr>TEXT</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="black">OCIS HAS AUTOMATICALLY ASSIGNED JUDGE CHIEF SPECIAL JUDGE TO THIS CASE.</font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow evenRow primary-entry">
+        <td valign="top">
+          <font color="BLACK"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="BLACK"><nobr>ADJUST</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="BLACK">ADJUSTING ENTRY: MONIES DUE TO AC09-CARD ALLOCATION</font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right">
+          <font color="green">$ 1.45</font>
+        </td>
+      </tr>
+      <tr class="docketRow oddRow primary-entry">
+        <td valign="top">
+          <font color="000000"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="000000"><nobr>ACCOUNT</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="000000">ADJUSTING ENTRY: MONIES DUE TO THE FOLLOWING AGENCIES REDUCED BY THE FOLLOWING AMOUNTS:<br>SC-2021-17934: AC64 DISPUTE MEDIATION FEES CIVIL ONLY -$0.18<br>SC-2021-17934: AC23 LAW LIBRARY FEE CIVIL AND CRIMINAL -$0.15<br>SC-2021-17934: AC01 CLERK FEES -$1.12<br></font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow evenRow primary-entry">
+        <td valign="top">
+          <font color="000000"><nobr>12-14-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="000000"><nobr>ACCOUNT</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="000000">RECEIPT # 2021-5112121 ON 12/14/2021. <br>
+ PAYOR: HARPER/SHILO TOTAL AMOUNT PAID: $ 58.00.<br>
+ LINE ITEMS:<br>
+ SC-2021-17934: $43.88 ON AC01 CLERK FEES.<br>
+ SC-2021-17934: $1.45 ON AC09 CARD ALLOCATIONS.<br>
+ SC-2021-17934: $5.85 ON AC23 LAW LIBRARY FEE CIVIL AND CRIMINAL.<br>
+ SC-2021-17934: $6.82 ON AC64 DISPUTE MEDIATION FEES CIVIL ONLY.<br></font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow oddRow primary-entry">
+        <td valign="top">
+          <font color="black"><nobr>12-15-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="black"><nobr>SMS</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="black">SUMMONS RETURNED, SERVED: PAMELA HENRY WITH HER DAUGHTER IFLE FIELDS AT USUAL PLACE OF RESIDENCE ON 12/14/21</font>
+            </p>
+            <p><span style="text-decoration: italic;">Document Available at Court Clerk's Office</span></p>
+          </div>
+        </td>
+        <td align="center" valign="top"></td>
+        <td valign="top"></td>
+        <td valign="top" align="right"></td>
+      </tr>
+      <tr class="docketRow evenRow primary-entry">
+        <td valign="top">
+          <font color="8B0000C"><nobr>12-21-2021&nbsp;</nobr></font>
+        </td>
+        <td valign="top">
+          <font class="docket_code" color="8B0000C"><nobr>DISPDNC</nobr></font>
+        </td>
+        <td valign="top">
+          <div class="description-wrapper">
+            <p>
+              <font color="8B0000C">JUDGE COLLINS CASE DISMISSED BY PLTF</font>
+            </p>
+          </div>
+        </td>
+        <td align="center" valign="top"><span class="count_issue">1&nbsp;&nbsp;</span></td>
+        <td valign="top"><span class="partyname">Henry, Pamela</span></td>
+        <td valign="top" align="right"></td>
+      </tr>
+    </tbody>
+  </table>

--- a/spec/parsers/docket_events_spec.rb
+++ b/spec/parsers/docket_events_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe OscnScraper::Parsers::DocketEvents do
         parsed_html = load_and_parse_fixture(fixture_path)
         data = described_class.parse(parsed_html)
         event_with_links = data[:docket_events].find { |de| de[:event_number] == 6 }
-        expected_keys = [:title, :link, :oscn_id]
+        expected_keys = %i[title link oscn_id]
 
         expect(event_with_links[:links].count).to eq 2
         expect(event_with_links[:links].first.keys - expected_keys).to eq []

--- a/spec/parsers/docket_events_spec.rb
+++ b/spec/parsers/docket_events_spec.rb
@@ -15,5 +15,21 @@ RSpec.describe OscnScraper::Parsers::DocketEvents do
 
       expect(data[:docket_events].count).to eq 224
     end
+
+    context 'when a link is in the docket event' do
+      it 'returns the links array' do
+        fixture_path = 'spec/fixtures/parsers/docket_events/with_link.html'
+        parsed_html = load_and_parse_fixture(fixture_path)
+        data = described_class.parse(parsed_html)
+        event_with_links = data[:docket_events].find { |de| de[:event_number] == 6 }
+        expected_keys = [:title, :link, :oscn_id]
+
+        expect(event_with_links[:links].count).to eq 2
+        expect(event_with_links[:links].first.keys - expected_keys).to eq []
+        first_link = event_with_links[:links].first
+        expect(first_link[:oscn_id]).to eq '1048798689'
+        expect(first_link[:title]).to eq 'TIFF'
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

Adds the links JSON to the docket events payload so that we can start scraping the links associated with a docket event. The payload is nested under the docket event like so:

```
{
    :event_number=>6,
    :date=>Tue, 14 Dec 2021,
    :code=>"P",
    :description=>
     "PETITION / FED / $ 1,818.60 Document Available (#1048798689) TIFF PDF",
    :count=>"",
    :party=>"",
    :amount=>"",
    :links=> [
       {
          :title=>"TIFF",
          :link=>"https://www.oscn.net/dockets/GetDocument.aspx?ct=Oklahoma&cn=SC-2021-17934&bc=1048798689&fmt=tif",
          :oscn_id=>"1048798689"},
      {
          :title=>"PDF",
          :link=> "https://www.oscn.net/dockets/GetDocument.aspx?ct=Oklahoma&bc=1048798689&cn=SC-2021-17934&fmt=pdf",
          :oscn_id=>"1048798689"
       }
    ]
},
```

This data is already set-up to be consumed by the oscn project. See:

[DocketEventLink Importer](https://github.com/AyOK-Code/oscn/blob/main/app/services/importers/docket_events/link.rb)
[DocketEvent Importer](https://github.com/AyOK-Code/oscn/blob/main/app/services/importers/docket_event.rb#L38)

However, the [gem ref:](https://github.com/AyOK-Code/oscn/blob/main/Gemfile#L18) will need to need to be updated once this change is deployed

## How to test

Run the spec from the project root directory:

```bash
rspec spec/parsers/docket_events_spec.rb
```
