### PR TITLE
Fix timezone issue

### DIFF
--- a/lib/oscn_scraper/parsers/events.rb
+++ b/lib/oscn_scraper/parsers/events.rb
@@ -57,8 +57,7 @@ module OscnScraper
         # Parse the date_string to a DateTime object
         time_in_central = Time.zone.parse(date_string)
         # Convert the time zone to UTC
-        datetime = time_in_central.utc.to_datetime
-        datetime
+        time_in_central.utc.to_datetime
       end
     end
   end

--- a/lib/oscn_scraper/parsers/events.rb
+++ b/lib/oscn_scraper/parsers/events.rb
@@ -52,7 +52,13 @@ module OscnScraper
 
       # TODO: move to helpers
       def parsed_date(date_string)
-        DateTime.parse("#{date_string} -06:00", '%A, %B %-d, %Y at %l:%m %p %z')
+        central_zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
+        Time.zone = central_zone
+        # Parse the date_string to a DateTime object
+        time_in_central = Time.zone.parse(date_string)
+        # Convert the time zone to UTC
+        datetime = time_in_central.utc.to_datetime
+        datetime
       end
     end
   end

--- a/spec/parsers/events_spec.rb
+++ b/spec/parsers/events_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe OscnScraper::Parsers::Events do
       data = described_class.parse(parsed_html)
 
       expect(data[:events].count).to eq 2
-      expect(data[:events].first[:date]).to eq DateTime.new(2023, 10, 19, 14, 1, 0o0, '+0000')
-      expect(data[:events].first).to include({ date: DateTime.new(2023, 10, 19, 14, 1, 0o0, '+0000'),
+      expect(data[:events].first[:date]).to eq DateTime.new(2023, 10, 19, 14, 0, 0o0, '+0000')
+      expect(data[:events].first).to include({ date: DateTime.new(2023, 10, 19, 14, 0, 0o0, '+0000'),
                                                event_type: 'ARRAIGNMENT',
                                                event_code: 'ARR',
                                                party_name: 'EDGAR,  JAMES  KEVIN',

--- a/spec/parsers/events_spec.rb
+++ b/spec/parsers/events_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe OscnScraper::Parsers::Events do
       data = described_class.parse(parsed_html)
 
       expect(data[:events].count).to eq 24
-      expect(data[:events].first).to include({ date: DateTime.new(2020, 5, 29, 9, 1, 0o0, '-0600'),
+      expect(data[:events].first[:date]).to eq DateTime.new(2020, 5, 29, 14, 1, 0o0, '+0000')
+      expect(data[:events].first).to include({ date: DateTime.new(2020, 5, 29, 14, 1, 0o0, '+0000'),
                                                event_type: 'NO ISSUE PRELIMINARY HEARING',
                                                event_code: 'PDP',
                                                party_name: 'COHEN,  JOHN  DAVID',


### PR DESCRIPTION
## Description

Event timestamps were always being sent back with hardcoded `-06:00` UTC time difference. Then daylight savings happened and `US Central` is now `-05:00`. This leverages the `ActiveSupport::TimeZone` to manage time zones automatically. There are no other timestamps on cases.