### PR TITLE
Add fix for blank events

### DIFF
--- a/lib/oscn_scraper/parsers/events.rb
+++ b/lib/oscn_scraper/parsers/events.rb
@@ -40,6 +40,7 @@ module OscnScraper
         event_code = event.search('.//comment()').text.squish.gsub('(', '').gsub(')', '')
         party_name = event.css('td')[1].text.strip
         docket = event.css('td')[2].text.strip
+        return nil if date.nil?
 
         events[:events] << {
           date: date,
@@ -57,6 +58,8 @@ module OscnScraper
         # Parse the date_string to a DateTime object
         time_in_central = Time.zone.parse(date_string)
         # Convert the time zone to UTC
+        return nil if time_in_central.nil?
+
         time_in_central.utc.to_datetime
       end
     end

--- a/spec/fixtures/parsers/events/missing_date.html
+++ b/spec/fixtures/parsers/events/missing_date.html
@@ -1,0 +1,37 @@
+<h2 class="section events">Events</h2>
+<script id="json_events" type="application/json">
+		{
+		"events": [
+		
+				{ 
+					"date": "",
+					"description":
+					  ""
+				}
+		]}
+	</script>
+  <table class="events_table" width="100%" id="TABLE_2">
+    <thead>
+      <tr>
+        <th>Event</th>
+        <th>Party</th>
+        <th>Docket</th>
+        <th>Reporter</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="event_description">
+          <font color="green"></font><br><span class="nbsps">&nbsp;&nbsp;&nbsp;</span><!--
+                            (None)
+                          -->
+        </td>
+        <td class="event_partyname empty">
+        </td>
+        <td class="event_judge empty">
+        </td>
+        <td class="event_reporter empty">
+        </td>
+      </tr>
+    </tbody>
+  </table>

--- a/spec/parsers/events_spec.rb
+++ b/spec/parsers/events_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe OscnScraper::Parsers::Events do
                                                docket: 'Arraignment Docket' })
     end
 
+    it 'skips events that do not have a date' do
+      fixture_path = 'spec/fixtures/parsers/events/missing_date.html'
+      html_doc = load_and_parse_fixture(fixture_path)
+      parsed_html = html_doc.css('table')
+      data = described_class.parse(parsed_html)
+      print data
+      expect(data[:events].count).to eq 0
+    end
+
     it 'parses a case with no events' do
       fixture_path = 'spec/fixtures/parsers/events/none.html'
       html_doc = load_and_parse_fixture(fixture_path)


### PR DESCRIPTION
## Description

Adds a fix for blank events which was causing the following error in the events parser

```
undefined method `utc' for nil:NilClass

        time_in_central.utc.to_datetime
                       ^^^^
```