### PR TITLE
Remove spaces from county name (only for Roger Mills)

### DIFF
--- a/lib/oscn_scraper/requestor/case.rb
+++ b/lib/oscn_scraper/requestor/case.rb
@@ -29,7 +29,7 @@ module OscnScraper
       def fetch_case_by_number
         required_params?(kwargs.keys, required_params)
         params = {
-          db: kwargs[:county].downcase,
+          db: kwargs[:county].downcase.delete(' '),
           number: kwargs[:number]
         }
         request(concatenated_url(endpoint, params))


### PR DESCRIPTION
## Description
The url for Roger Mills counties has the county name as rogermills (no spaces). This was preventing us from scraping the cases.

## How to test
Confirm that new case html is getting scraped in for RogerMills cases


## Checklist
- [ ] bump versions on depednent repositories
